### PR TITLE
Add ability to patch RSTB via commandline

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using HeavenTool.Forms.RSTB;
+using HeavenTool.Utility.FileTypes.RSTB;
 using HeavenTool.Utility.IO;
 using Microsoft.Win32.SafeHandles;
 using System;
@@ -103,10 +104,24 @@ internal static class Program
                 return bcsvEditor;
 
             case ".srsizetable":
-                var rstbEditor = new RSTBEditor();
-                rstbEditor.LoadFile(path);
-                return rstbEditor;
-
+                if (originalArguments.Length >= 2)
+                {
+                    var rstbEditor = new RSTBEditor();
+                    rstbEditor.LoadFile(path);
+                    rstbEditor.CreateUpdatedRSTBFromModdedRomFs(rstbEditor.LoadedFile, originalArguments[1], false);
+                    string outPath = path;
+                    if (originalArguments.Length >= 3)
+                        outPath = originalArguments[2];
+                    rstbEditor.LoadedFile.SaveTo(outPath, false);
+                    Environment.Exit(0);
+                    return null;
+                }
+                else
+                {
+                    var rstbEditor = new RSTBEditor();
+                    rstbEditor.LoadFile(path);
+                    return rstbEditor;
+                }
             default: 
                 return null;
         }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Heaven Tool": {
+      "commandName": "Project",
+      "commandLineArgs": "C:\\Users\\Ryan\\Documents\\GitHub\\ACNH-Tutorial-Skip\\RSTB_OG\\ResourceSizeTableTest.srsizetable C:\\Users\\Ryan\\AppData\\Roaming\\Ryujinx\\mods\\contents\\01006f8002326000\\romfs"
+    }
+  }
+}

--- a/Utility/FileTypes/RSTB/ResourceTable.cs
+++ b/Utility/FileTypes/RSTB/ResourceTable.cs
@@ -306,7 +306,7 @@ public class ResourceTable : IDisposable
     /// Save the file
     /// </summary>
     /// <param name="filePath">File Location</param>
-    public void SaveTo(string filePath)
+    public void SaveTo(string filePath, bool showPrompt = true)
     {
         UpdateUniques();
 
@@ -337,7 +337,9 @@ public class ResourceTable : IDisposable
             memoryStream.Position = 0;
             memoryStream.Read(array, 0, array.Length);
 
-            var wantToCompress = MessageBox.Show("Do you want to compress the file?", "Compress to Yaz0?", MessageBoxButtons.YesNo);
+            var wantToCompress = DialogResult.Yes;
+            if (showPrompt)
+                wantToCompress = MessageBox.Show("Do you want to compress the file?", "Compress to Yaz0?", MessageBoxButtons.YesNo);
             var result = wantToCompress == DialogResult.Yes ? Yaz0CompressionAlgorithm.Compress(array) : new MemoryStream(array);
 
             result.ExportToFile(filePath);


### PR DESCRIPTION
Here are some changes I made so that I could update my RSTB via heaventool with one click, which is handy for adding the RSTB patching process to batch files.  
### How It's Implemented
- The RSTB updating function has been separated from the ``UpdateFromModdedRomFs_Click`` procedure and made public so it can be reused in Program.cs for commandline arguments.
- When more than one commandline argument is supplied for RSTB editing, the program will assume the 2nd argument is the path to the romFS folder and use that to overwrite the input RSTB with a patched one. 
- If a third argument is supplied, it will assume the 3rd path is the output RSTB and save it there instead of overwriting.  
  
To make this work without further user input, I had to add bools for whether or not to show messagebox prompts to the RSTB saving and updating functions. This way, the program assumes that you always want to compress the RSTB and doesn't show the results messagebox when updating via commandline.
### Possible Issues
One issue I've noticed is that occasionally there is a popup about the collection being modified while in a for loop. I assume this is some kind of race condition relating to the RSTB update function being asynchronous, but I'm not sure.